### PR TITLE
Add hook that check commit with with .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .next
 node_modules
+.env

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,16 @@
 npx commitlint --edit $1
+STAGED_ENV=$(git diff --cached --name-only --diff-filter=ACM | grep -E '(^|/)\.env(\..*)?$' || true)
+
+if [ -n "$STAGED_ENV" ]; then
+  echo "⚠ Commit blocked: .env file detected in staged changes."
+  echo "Files found:"
+  echo "$STAGED_ENV"
+  echo ""
+  echo "Add .env files to your .gitignore and remove it from tracking:"
+  echo "  git rm --cached .env '...'"
+  echo "To skip this hook:"
+  echo "  git commit -m '...' -n"
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
A minha implementação para resolver a Issue #51 foi adicionar um git hook que verifica se um arquivo com a substring .env foi enviado. Caso algum arquivo entre na regra do hook, é mostrado no terminal um aviso com os arquivos .env no commit bloqueado. 